### PR TITLE
commandline: multiple commandnames support

### DIFF
--- a/src/Orchard.Environment.Commands/CommandDescriptor.cs
+++ b/src/Orchard.Environment.Commands/CommandDescriptor.cs
@@ -2,7 +2,7 @@
 
 namespace Orchard.Environment.Commands {
     public class CommandDescriptor {
-        public string Name { get; set; }
+        public string[] Names { get; set; }
         public MethodInfo MethodInfo { get; set; }
         public string HelpText { get; set; }
     }

--- a/src/Orchard.Environment.Commands/CommandHandlerDescriptorBuilder.cs
+++ b/src/Orchard.Environment.Commands/CommandHandlerDescriptorBuilder.cs
@@ -21,7 +21,7 @@ namespace Orchard.Environment.Commands {
 
         private CommandDescriptor BuildMethod(MethodInfo methodInfo) {
             return new CommandDescriptor {
-                Name = GetCommandName(methodInfo),
+                Names = GetCommandNames(methodInfo),
                 MethodInfo = methodInfo,
                 HelpText = GetCommandHelpText(methodInfo)
             };
@@ -35,13 +35,13 @@ namespace Orchard.Environment.Commands {
             return string.Empty;
         }
 
-        private string GetCommandName(MethodInfo methodInfo) {
+        private string[] GetCommandNames(MethodInfo methodInfo) {
             var attributes = methodInfo.GetCustomAttributes(typeof(CommandNameAttribute), false/*inherit*/);
             if (attributes != null && attributes.Any()) {
-                return attributes.Cast<CommandNameAttribute>().Single().Command;
+                return attributes.Cast<CommandNameAttribute>().Single().Commands;
             }
 
-            return methodInfo.Name.Replace('_', ' ');
+            return new []{methodInfo.Name.Replace('_', ' ')};
         }
     }
 }

--- a/src/Orchard.Environment.Commands/CommandNameAttribute.cs
+++ b/src/Orchard.Environment.Commands/CommandNameAttribute.cs
@@ -3,25 +3,19 @@
 namespace Orchard.Environment.Commands {
     [AttributeUsage(AttributeTargets.Method)]
     public class CommandNameAttribute : Attribute {
-        private readonly string _commandAlias;
-
-        public CommandNameAttribute(string commandAlias) {
-            _commandAlias = commandAlias;
+        public CommandNameAttribute(params string[] commandsAlias) {
+            Commands = commandsAlias;
         }
 
-        public string Command {
-            get { return _commandAlias; }
-        }
+        public string[] Commands { get; }
     }
 
     [AttributeUsage(AttributeTargets.Method)]
     public class CommandHelpAttribute : Attribute {
-        private readonly string _helpText;
-
         public CommandHelpAttribute(string helpText) {
-            _helpText = helpText;
+            HelpText = helpText;
         }
 
-        public string HelpText { get { return _helpText; } }
+        public string HelpText { get; }
     }
 }

--- a/src/Orchard.Environment.Commands/DefaultCommandManager.cs
+++ b/src/Orchard.Environment.Commands/DefaultCommandManager.cs
@@ -10,7 +10,7 @@ namespace Orchard.Environment.Commands {
 
         public DefaultCommandManager(IEnumerable<ICommandHandler> commandHandlers) {
             _commandHandlers = commandHandlers;
-            
+
             T = NullLocalizer.Instance;
         }
 
@@ -25,13 +25,13 @@ namespace Orchard.Environment.Commands {
             }
             else {
                 var commandMatch = string.Join(" ", parameters.Arguments.ToArray());
-                var commandList = string.Join(",", GetCommandDescriptors().Select(d => d.Name).ToArray());
+                var commandList = string.Join(",", GetCommandDescriptors().SelectMany(d => d.Names).ToArray());
                 if (matches.Any()) {
                     throw new OrchardCoreException(T("Multiple commands found matching arguments \"{0}\". Commands available: {1}.",
-                                                             commandMatch, commandList));
+                        commandMatch, commandList));
                 }
                 throw new OrchardCoreException(T("No command found matching arguments \"{0}\". Commands available: {1}.",
-                                                 commandMatch, commandList));
+                    commandMatch, commandList));
             }
         }
 
@@ -43,7 +43,7 @@ namespace Orchard.Environment.Commands {
             // Command names are matched with as many arguments as possible, in decreasing order
             foreach (var argCount in Enumerable.Range(1, parameters.Arguments.Count()).Reverse()) {
                 int count = argCount;
-                var matches = _commandHandlers.SelectMany(h => 
+                var matches = _commandHandlers.SelectMany(h =>
                     MatchCommands(parameters, count, _builder.Build(h.GetType()), h)).ToList();
                 if (matches.Any())
                     return matches;
@@ -54,23 +54,22 @@ namespace Orchard.Environment.Commands {
 
         private static IEnumerable<Match> MatchCommands(CommandParameters parameters, int argCount, CommandHandlerDescriptor descriptor, ICommandHandler handler) {
             foreach (var commandDescriptor in descriptor.Commands) {
-                var names = commandDescriptor.Name.Split(' ');
-                if (!parameters.Arguments.Take(argCount).SequenceEqual(names, StringComparer.OrdinalIgnoreCase)) {
-                    // leading arguments not equal to command name
-                    continue;
+                foreach (var name in commandDescriptor.Names) {
+                    var names = name.Split(' ');
+                    if (parameters.Arguments.Take(argCount).SequenceEqual(names, StringComparer.OrdinalIgnoreCase)) {
+                        yield return new Match {
+                            Context = new CommandContext {
+                                Arguments = parameters.Arguments.Skip(names.Count()),
+                                Command = string.Join(" ", names),
+                                CommandDescriptor = commandDescriptor,
+                                Input = parameters.Input,
+                                Output = parameters.Output,
+                                Switches = parameters.Switches,
+                            },
+                            CommandHandler = handler
+                        };
+                    }
                 }
-
-                yield return new Match {
-                    Context = new CommandContext {
-                        Arguments = parameters.Arguments.Skip(names.Count()),
-                        Command = string.Join(" ", names),
-                        CommandDescriptor = commandDescriptor,
-                        Input = parameters.Input,
-                        Output = parameters.Output,
-                        Switches = parameters.Switches,
-                    },
-                    CommandHandler = handler
-                };
             }
         }
 

--- a/test/Orchard.Tests/Commands/CommandHandlerDescriptorBuilderTests.cs
+++ b/test/Orchard.Tests/Commands/CommandHandlerDescriptorBuilderTests.cs
@@ -11,14 +11,14 @@ namespace Orchard.Tests.Commands {
             var descriptor = builder.Build(typeof(MyCommand));
             Assert.NotNull(descriptor);
             Assert.Equal(4, descriptor.Commands.Count());
-            Assert.NotNull(descriptor.Commands.SingleOrDefault(d => d.Name == "FooBar"));
-            Assert.Equal(typeof(MyCommand).GetMethod("FooBar"), descriptor.Commands.Single(d => d.Name == "FooBar").MethodInfo);
-            Assert.NotNull(descriptor.Commands.SingleOrDefault(d => d.Name == "MyCommand"));
-            Assert.Equal(typeof(MyCommand).GetMethod("FooBar2"), descriptor.Commands.Single(d => d.Name == "MyCommand").MethodInfo);
-            Assert.NotNull(descriptor.Commands.SingleOrDefault(d => d.Name == "Foo Bar"));
-            Assert.Equal(typeof(MyCommand).GetMethod("Foo_Bar"), descriptor.Commands.Single(d => d.Name == "Foo Bar").MethodInfo);
-            Assert.NotNull(descriptor.Commands.SingleOrDefault(d => d.Name == "Foo_Bar"));
-            Assert.Equal(typeof(MyCommand).GetMethod("Foo_Bar3"), descriptor.Commands.Single(d => d.Name == "Foo_Bar").MethodInfo);
+            Assert.NotNull(descriptor.Commands.SingleOrDefault(d => d.Names.Contains("FooBar")));
+            Assert.Equal(typeof(MyCommand).GetMethod("FooBar"), descriptor.Commands.Single(d => d.Names.Contains("FooBar")).MethodInfo);
+            Assert.NotNull(descriptor.Commands.SingleOrDefault(d => d.Names.Contains("MyCommand")));
+            Assert.Equal(typeof(MyCommand).GetMethod("FooBar2"), descriptor.Commands.Single(d => d.Names.Contains("MyCommand")).MethodInfo);
+            Assert.NotNull(descriptor.Commands.SingleOrDefault(d => d.Names.Contains("Foo Bar")));
+            Assert.Equal(typeof(MyCommand).GetMethod("Foo_Bar"), descriptor.Commands.Single(d => d.Names.Contains("Foo Bar")).MethodInfo);
+            Assert.NotNull(descriptor.Commands.SingleOrDefault(d => d.Names.Contains("Foo_Bar")));
+            Assert.Equal(typeof(MyCommand).GetMethod("Foo_Bar3"), descriptor.Commands.Single(d => d.Names.Contains("Foo_Bar")).MethodInfo);
         }
 
         public class MyCommand : DefaultOrchardCommandHandler {
@@ -43,7 +43,7 @@ namespace Orchard.Tests.Commands {
             var descriptor = builder.Build(typeof(PublicMethodsOnly));
             Assert.NotNull(descriptor);
             Assert.Equal(1, descriptor.Commands.Count());
-            Assert.NotNull(descriptor.Commands.SingleOrDefault(d => d.Name == "Method"));
+            Assert.NotNull(descriptor.Commands.SingleOrDefault(d => d.Names.Contains("Method")));
         }
 
 #pragma warning disable 660,661

--- a/test/Orchard.Tests/Commands/CommandHandlerTests.cs
+++ b/test/Orchard.Tests/Commands/CommandHandlerTests.cs
@@ -27,7 +27,7 @@ namespace Orchard.Tests.Commands {
 
             var descriptor = builder.Build(typeof(StubCommandHandler));
 
-            var commandDescriptor = descriptor.Commands.Single(d => string.Equals(d.Name, commandName, StringComparison.OrdinalIgnoreCase));
+            var commandDescriptor = descriptor.Commands.Single(d => d.Names.Any(x=> string.Equals(x, commandName, StringComparison.OrdinalIgnoreCase)));
 
             return new CommandContext {
                 Command = commandName,


### PR DESCRIPTION
Can we add this to the project? This way its possible to set multiple commandnames in the attribute. like long and short name.

eg. 
```
[CommandName("codegen ext", "codegen extension")]
```