### PR TITLE
Fixed bug with running in shell settings

### DIFF
--- a/src/Orchard.Environment.Shell.Abstractions/ShellSettings.cs
+++ b/src/Orchard.Environment.Shell.Abstractions/ShellSettings.cs
@@ -86,7 +86,7 @@ namespace Orchard.Environment.Shell {
         }
 
         private string StringNullReconfiguration(string value) {
-            if (value.Equals("null", StringComparison.CurrentCultureIgnoreCase)) {
+            if (string.IsNullOrWhiteSpace(value) || value.Equals("null", StringComparison.CurrentCultureIgnoreCase)) {
                 return null;
             }
             return value;


### PR DESCRIPTION
***.\dnx web:***

```
PS D:\Src\Brochard\src\Orchard.Web> dnx web
info: Orchard.Hosting.DefaultOrchardHost[0]
      Initialize Host
info: Orchard.Hosting.DefaultOrchardHost[0]
      Start creation of shells
info: Orchard.Environment.Extensions.Folders.ExtensionHarvester[0]
      Start looking for extensions in '~/Core/Orchard.Core'...
info: Orchard.Environment.Extensions.Folders.ExtensionHarvester[0]
      Done looking for extensions in '~/Core/Orchard.Core': Settings
info: Orchard.Environment.Extensions.Folders.ExtensionHarvester[0]
      Start looking for extensions in '~/Modules'...
info: Orchard.Environment.Extensions.Folders.ExtensionHarvester[0]
      Done looking for extensions in '~/Modules': Orchard.Data.EntityFramework, Orchard.Demo, Orchard.Logging.Console, Orchard.Setup
info: Orchard.Environment.Extensions.ExtensionManager[0]
      Loading features
info: Orchard.Environment.Extensions.Loaders.DynamicExtensionLoader[0]
      Loaded referenced extension "Console Logging": assembly name="Orchard.Logging.Console, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null"
info: Orchard.Environment.Extensions.Loaders.DynamicExtensionLoader[0]
      Loaded referenced extension "Orchard.Setup": assembly name="Orchard.Setup, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null"
info: Orchard.Environment.Extensions.ExtensionManager[0]
      Done loading features
Application startup exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Orchard.Environment.Shell.ShellSettings.StringNullReconfiguration(String value) in D:\Src\Brochard\src\Orchard.Environment.Shell.Abstractions\ShellSettings.cs:line 89
   at Orchard.Environment.Shell.ShellSettings.get_RequestUrlHost() in D:\Src\Brochard\src\Orchard.Environment.Shell.Abstractions\ShellSettings.cs:line 64
   at Orchard.Hosting.Web.Routing.Routes.RoutePublisher.Publish(IEnumerable`1 routes, RequestDelegate pipeline) in D:\Src\Brochard\src\Orchard.Hosting.Web\Routing\Routes\RoutePublisher.cs:line 38
   at Orchard.Hosting.OrchardShell.Activate() in D:\Src\Brochard\src\Orchard.Hosting.Web\OrchardShell.cs:line 55
   at Orchard.Hosting.DefaultOrchardHost.ActivateShell(ShellContext context) in D:\Src\Brochard\src\Orchard.Hosting\DefaultOrchardHost.cs:line 93
   at Orchard.Hosting.DefaultOrchardHost.CreateAndActivateShells() in D:\Src\Brochard\src\Orchard.Hosting\DefaultOrchardHost.cs:line 82
   at Orchard.Hosting.DefaultOrchardHost.BuildCurrent() in D:\Src\Brochard\src\Orchard.Hosting\DefaultOrchardHost.cs:line 48
   at Orchard.Hosting.DefaultOrchardHost.Orchard.Hosting.IOrchardHost.Initialize() in D:\Src\Brochard\src\Orchard.Hosting\DefaultOrchardHost.cs:line 37
   at Orchard.Web.Startup.Configure(IApplicationBuilder builder, ILoggerFactory loggerFactory, IOrchardHost orchardHost) in D:\Src\Brochard\src\Orchard.Web\Startup.cs:line 23
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at Microsoft.AspNet.Hosting.Startup.ConfigureBuilder.Invoke(Object instance, IApplicationBuilder builder)
   at Microsoft.AspNet.Hosting.Internal.HostingEngine.BuildApplication()
fail: Microsoft.AspNet.Hosting.Internal.HostingEngine[7]
      Application startup exception
      System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.NullReferenceException: Object reference not set to an instance of an object.
         at Orchard.Environment.Shell.ShellSettings.StringNullReconfiguration(String value) in D:\Src\Brochard\src\Orchard.Environment.Shell.Abstractions\ShellSettings.cs:line 89
         at Orchard.Environment.Shell.ShellSettings.get_RequestUrlHost() in D:\Src\Brochard\src\Orchard.Environment.Shell.Abstractions\ShellSettings.cs:line 64
         at Orchard.Hosting.Web.Routing.Routes.RoutePublisher.Publish(IEnumerable`1 routes, RequestDelegate pipeline) in D:\Src\Brochard\src\Orchard.Hosting.Web\Routing\Routes\RoutePublisher.cs:line 38
         at Orchard.Hosting.OrchardShell.Activate() in D:\Src\Brochard\src\Orchard.Hosting.Web\OrchardShell.cs:line 55
         at Orchard.Hosting.DefaultOrchardHost.ActivateShell(ShellContext context) in D:\Src\Brochard\src\Orchard.Hosting\DefaultOrchardHost.cs:line 93
         at Orchard.Hosting.DefaultOrchardHost.CreateAndActivateShells() in D:\Src\Brochard\src\Orchard.Hosting\DefaultOrchardHost.cs:line 82
         at Orchard.Hosting.DefaultOrchardHost.BuildCurrent() in D:\Src\Brochard\src\Orchard.Hosting\DefaultOrchardHost.cs:line 48
         at Orchard.Hosting.DefaultOrchardHost.Orchard.Hosting.IOrchardHost.Initialize() in D:\Src\Brochard\src\Orchard.Hosting\DefaultOrchardHost.cs:line 37
         at Orchard.Web.Startup.Configure(IApplicationBuilder builder, ILoggerFactory loggerFactory, IOrchardHost orchardHost) in D:\Src\Brochard\src\Orchard.Web\Startup.cs:line 23
         --- End of inner exception stack trace ---
         at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
         at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
         at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
         at Microsoft.AspNet.Hosting.Startup.ConfigureBuilder.Invoke(Object instance, IApplicationBuilder builder)
         at Microsoft.AspNet.Hosting.Internal.HostingEngine.BuildApplication()
verb: Microsoft.AspNet.Hosting.Internal.HostingEngine[4]
      Hosting starting
verb: Microsoft.AspNet.Hosting.Internal.HostingEngine[5]
      Hosting started
Hosting environment: Production
Now listening on: http://localhost:5001
Now listening on: http://localhost:5002
Application started. Press Ctrl+C to shut down.
```